### PR TITLE
Forbid start if node_modules integrarity does not pas verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "config/main.js",
   "license": "MIT",
   "scripts": {
-    "start": "concurrently \"cross-env BROWSER=none yarn dev\" \"wait-on http://0.0.0.0:8080 && yarn electron:dev\"",
+    "start": "yarn check --integrity && concurrently \"cross-env BROWSER=none yarn dev\" \"wait-on http://0.0.0.0:8080 && yarn electron:dev\"",
     "dev": "webpack-dev-server --config config/webpack-dev.config.js --mode development --open --hot",
     "build": "rm -rf build && webpack --config config/webpack-prod.config.js --mode production --env.NODE_ENV=production",
     "lint:precommit": "eslint ./app/",


### PR DESCRIPTION
Ensures you can't run the app if you forgot to `yarn install` first, it checks node_modules against yarn.lock and package.json